### PR TITLE
FIx handling of OPc in HSS

### DIFF
--- a/src/de/fhg/fokus/hss/cx/op/MAR.java
+++ b/src/de/fhg/fokus/hss/cx/op/MAR.java
@@ -378,7 +378,7 @@ public class MAR {
 	            // get op and generate opC only if OPc is not present, if both are present take OP
         		byte [] op;
         		byte [] opC;
-	            if (HexCodec.encode(impi.getOpc()) != HSSProperties.OPC && HexCodec.encode(impi.getOp()) == HSSProperties.OPERATOR_ID) {
+	            if (!HexCodec.encode(impi.getOpc()).equals(HSSProperties.OPC) && HexCodec.encode(impi.getOp()).equals(HSSProperties.OPERATOR_ID)) {
 	            	opC = impi.getOpc();
 	            } else {
 	            	op = impi.getOp();
@@ -528,7 +528,7 @@ public class MAR {
                 // generate opC        
                 byte[] opC;
         		try {
-        			if (HexCodec.encode(impi.getOpc()) != HSSProperties.OPC && HexCodec.encode(impi.getOp()) == HSSProperties.OPERATOR_ID) {
+        			if (!HexCodec.encode(impi.getOpc()).equals(HSSProperties.OPC) && HexCodec.encode(impi.getOp()).equals(HSSProperties.OPERATOR_ID)) {
 	            		opC = impi.getOpc();
 		            } else {
 						opC = Milenage.generateOpC(secretKey, op);

--- a/src/de/fhg/fokus/hss/zh/op/MAR.java
+++ b/src/de/fhg/fokus/hss/zh/op/MAR.java
@@ -219,7 +219,7 @@ public class MAR{
 	            // get op and generate opC only if OPc is not present, if both are present take OP
         		byte [] op;
         		byte [] opC;
-	            if (HexCodec.encode(impi.getOpc()) != HSSProperties.OPC && HexCodec.encode(impi.getOp()) == HSSProperties.OPERATOR_ID) {
+	            if (!HexCodec.encode(impi.getOpc()).equals(HSSProperties.OPC) && HexCodec.encode(impi.getOp()).equals(HSSProperties.OPERATOR_ID)) {
 	            	opC = impi.getOpc();
 	            } else {
 	            	op = impi.getOp();
@@ -385,7 +385,7 @@ public class MAR{
                 
                 byte[] opC;
         		try {
-        			if (HexCodec.encode(impi.getOpc()) != HSSProperties.OPC && HexCodec.encode(impi.getOp()) == HSSProperties.OPERATOR_ID) {
+        			if (!HexCodec.encode(impi.getOpc()).equals(HSSProperties.OPC) && HexCodec.encode(impi.getOp()).equals(HSSProperties.OPERATOR_ID)) {
 	            		opC = impi.getOpc();
 		            } else {
 						opC = Milenage.generateOpC(secretKey, op);


### PR DESCRIPTION
We cannot use '==' to compare two strings in Java.  This would only
compare the references to the strings, but not the actual content.

As the database-read OP/OPc strings are dynamically allocated, their
reference (address) cannot be identical to the property.  We have to
use the .equals() method to compare the actual contents.

This fixes #4.